### PR TITLE
Update constructor options to match aws-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@
 npm install --save @bizon/mws-sdk
 ```
 
+## Usage
+
+```js
+const MWSClient = require('@bizon/mws-sdk')
+
+const client = new MWSClient({
+  accessKeyId: '', // defaults to process.env.MWS_ACCESS_KEY_ID
+  secretAccessKey: '', // defaults to process.env.MWS_SECRET_ACCESS_KEY
+  sellerId: '',
+  mwsToken: '',
+  sellerRegion: ''
+})
+```
+
 ## API
 
 ### Finances

--- a/__tests__/lib/client/index.js
+++ b/__tests__/lib/client/index.js
@@ -1,0 +1,54 @@
+const MWSClient = require('../../../lib/client')
+
+describe('lib.client.index', () => {
+  it('should fail if accessKeyId, secretAccessKey, sellerId or mwsToken is not specified', () => {
+    const tests = [
+      () => new MWSClient(),
+      () => new MWSClient({
+        accessKeyId: 'foo'
+      }),
+      () => new MWSClient({
+        accessKeyId: 'foo',
+        secretAccessKey: 'bar'
+      }),
+      () => new MWSClient({
+        accessKeyId: 'foo',
+        secretAccessKey: 'bar',
+        sellerId: 'baz'
+      })
+    ]
+
+    for (const test of tests) {
+      expect(test).toThrow('accessKeyId, secretAccessKey, sellerId and mwsToken are required')
+    }
+  })
+
+  it('should fail if the region is unknown', () => {
+    expect(
+      () => new MWSClient({
+        accessKeyId: 'foo',
+        secretAccessKey: 'bar',
+        sellerId: 'baz',
+        mwsToken: 'token',
+        sellerRegion: 'unknown'
+      })
+    ).toThrow('Unknown region unknown')
+  })
+
+  it('should grab accessKeyId and secretAccessKey from the environment', () => {
+    process.env.MWS_ACCESS_KEY_ID = 'foo'
+    process.env.MWS_SECRET_ACCESS_KEY = 'bar'
+
+    const client = new MWSClient({
+      sellerId: 'baz',
+      mwsToken: 'token',
+      sellerRegion: 'eu'
+    })
+
+    expect(client.settings.accessKeyId).toBe(process.env.MWS_ACCESS_KEY_ID)
+    expect(client.settings.secretAccessKey).toBe(process.env.MWS_SECRET_ACCESS_KEY)
+
+    delete process.env.MWS_ACCESS_KEY_ID
+    delete process.env.MWS_SECRET_ACCESS_KEY
+  })
+})

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -17,9 +17,18 @@ const _signData = Symbol('signData')
 const USER_AGENT = `bizon/mws-sdk/${pkg.version} (https://bizon.solutions)`
 
 class Client {
-  constructor(accessKey, secretKey, sellerId, mwsToken, sellerRegion) {
-    if (!accessKey || !secretKey || !sellerId || !mwsToken) {
-      throw new TypeError('accessKey, secretKey, sellerId and mwsToken are required')
+  constructor({
+    accessKeyId,
+    secretAccessKey,
+    sellerId,
+    mwsToken,
+    sellerRegion
+  } = {}) {
+    accessKeyId = accessKeyId || process.env.MWS_ACCESS_KEY_ID
+    secretAccessKey = secretAccessKey || process.env.MWS_SECRET_ACCESS_KEY
+
+    if (!accessKeyId || !secretAccessKey || !sellerId || !mwsToken) {
+      throw new TypeError('accessKeyId, secretAccessKey, sellerId and mwsToken are required')
     }
 
     const region = regions[sellerRegion]
@@ -28,8 +37,8 @@ class Client {
     }
 
     this.settings = {
-      accessKey,
-      secretKey,
+      accessKeyId,
+      secretAccessKey,
       sellerId,
       mwsToken,
       region


### PR DESCRIPTION
Rename accessKey to accessKeyId and secretKey to secretAccessKey.
Require options to be passed as a hash.
Allow passing the credentials to be passed using env variables.