### PR TITLE
Support errors in getMatchingProductForId

### DIFF
--- a/__tests__/lib/client/parsers/products/__snapshots__/get-matching-product-for-id-response.js.snap
+++ b/__tests__/lib/client/parsers/products/__snapshots__/get-matching-product-for-id-response.js.snap
@@ -4,6 +4,7 @@ exports[`lib.client.parsers.products.get-matching-product-for-id-response should
 Object {
   "getMatchingProductForIdResults": Array [
     Object {
+      "error": null,
       "id": "B002KT3XRQ",
       "idType": "ASIN",
       "products": Array [
@@ -133,12 +134,19 @@ exports[`lib.client.parsers.products.get-matching-product-for-id-response should
 Object {
   "getMatchingProductForIdResults": Array [
     Object {
+      "error": Object {
+        "code": "InvalidParameterValue",
+        "detail": null,
+        "message": "Invalid ISBN identifier 0439708623 for marketplace ATVPDKIKX0DER",
+        "type": "Sender",
+      },
       "id": "0439708623",
       "idType": "ISBN",
       "products": Array [],
       "status": "ClientError",
     },
     Object {
+      "error": null,
       "id": "9781933988665",
       "idType": "ISBN",
       "products": Array [
@@ -277,6 +285,7 @@ exports[`lib.client.parsers.products.get-matching-product-for-id-response should
 Object {
   "getMatchingProductForIdResults": Array [
     Object {
+      "error": null,
       "id": "9781933988665",
       "idType": "ISBN",
       "products": Array [
@@ -403,6 +412,7 @@ Object {
       "status": "Success",
     },
     Object {
+      "error": null,
       "id": "0439708184",
       "idType": "ISBN",
       "products": Array [
@@ -629,6 +639,7 @@ exports[`lib.client.parsers.products.get-matching-product-for-id-response should
 Object {
   "getMatchingProductForIdResults": Array [
     Object {
+      "error": null,
       "id": "B002KT3XRQ",
       "idType": "ASIN",
       "products": Array [

--- a/lib/client/parsers/base/error.js
+++ b/lib/client/parsers/base/error.js
@@ -1,0 +1,8 @@
+const {parseStr} = require('.')
+
+module.exports = (key, node) => ({
+  type: parseStr(`${key}/*[local-name() = 'Type']`, node),
+  code: parseStr(`${key}/*[local-name() = 'Code']`, node),
+  message: parseStr(`${key}/*[local-name() = 'Message']`, node),
+  detail: parseStr(`${key}/*[local-name() = 'Detail']`, node)
+})

--- a/lib/client/parsers/products/get-matching-product-for-id-result.js
+++ b/lib/client/parsers/products/get-matching-product-for-id-result.js
@@ -1,6 +1,8 @@
 const select = require('../select')
+const nullable = require('../nullable')
 
 const {parseAttributeStr} = require('../base/attributes')
+const parseError = require('../base/error')
 
 const parseProduct = require('./product')
 
@@ -10,5 +12,6 @@ module.exports = (key, node) => ({
   status: parseAttributeStr(key, node, 'status'),
   products: select(`${key}/products:Products/products:Product`, node).map(n => {
     return parseProduct('.', n)
-  })
+  }),
+  error: nullable(parseError, `${key}/products:Error`, node)
 })


### PR DESCRIPTION
This allows to support https://github.com/bizon/mws-api-doc/blob/master/doc/en_FR/products/Products_GetMatchingProductForId.md#example-response-with-error.