### PR TITLE
Add generic error handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ const client = new MWSClient({
 
 Keep in mind that the specified marketplaces will have to be in the same MWS region, otherwise an error will be thrown.
 
+## Error handling
+
+Whenever the MWS API returns a non 200 HTTP status, a `MWSError` will be thrown. Use `error.body` to inspect the contents of the error, and `error.response` to access the raw HTTP response.
+
+```js
+const {MWSError} = '@bizon/mws-sdk'
+
+try {
+  const result = await client.products.getLowestPricedOffersForSku({
+    marketplaceId: 'A1F83G8C2ARO7P',
+    sellerSku: 'some-sku',
+    itemCondition: 'new'
+  })
+} catch (error) {
+  if (error instanceof MWSError) {
+    console.log(error.body) // This will contain the parsed XML body
+    console.log(error.response.statusCode)
+  }
+}
+```
+
 ## API
 
 ### Finances

--- a/__tests__/lib/client/__snapshots__/index.js.snap
+++ b/__tests__/lib/client/__snapshots__/index.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lib.client.index should throw default a MWSError when encountering an unhandled HTTPError on GET 1`] = `
+Object {
+  "error": Object {
+    "code": "QuotaExceeded",
+    "detail": null,
+    "message": "You exceeded your quota of 200.0 requests per 1 hour for operation CustomResource/1988-10-13/CustomAction.  Your quota will reset on Thu Apr 04 18:46:00 UTC 2020",
+    "type": "",
+  },
+  "responseMetadata": Object {
+    "requestId": "bc6e4601-3d74-4612-adcf-EXAMPLEf1796",
+  },
+}
+`;
+
+exports[`lib.client.index should throw default a MWSError when encountering an unhandled HTTPError on POST 1`] = `
+Object {
+  "error": Object {
+    "code": "ClientError",
+    "detail": null,
+    "message": "bar is not valid for Foo",
+    "type": null,
+  },
+  "responseMetadata": Object {
+    "requestId": "bc6e4601-3d74-4612-adcf-EXAMPLEf1796",
+  },
+}
+`;

--- a/__tests__/lib/client/error.js
+++ b/__tests__/lib/client/error.js
@@ -18,14 +18,45 @@ describe('lib.client.error', () => {
     }
   })
 
-  it('should fail if resource or method is not defined', () => {
+  it('should fail if resource or action is not defined', () => {
     const tests = [
       () => new MWSError(new HTTPError({})),
       () => new MWSError(new HTTPError({}), 'Order')
     ]
 
     for (const test of tests) {
-      expect(test).toThrow('The resource and method parameters are required')
+      expect(test).toThrow('The resource and action parameters are required')
+    }
+  })
+
+  it('should not allow updating error properties', () => {
+    const error = new MWSError(
+      new HTTPError({
+        statusCode: 400,
+        statusMessage: 'Something wrong happened',
+        body: `<ErrorResponse>
+          <Error>
+            <Message>This is a message</Message>
+          </Error>
+        </ErrorResponse>`
+      }),
+      'ResourceName',
+      'Function'
+    )
+
+    const properties = [
+      'response',
+      'resource',
+      'action',
+      'body'
+    ]
+
+    for (const property of properties) {
+      error[property] = 'override'
+      expect(error[property]).not.toEqual('override')
+
+      delete error[property]
+      expect(error[property]).toBeDefined()
     }
   })
 

--- a/lib/client/error.js
+++ b/lib/client/error.js
@@ -12,27 +12,43 @@ function parseDefaultErrorResponse(key, node) {
 }
 
 class MWSError extends Error {
-  constructor(httpError, resource, method, parseErrorResponse = parseDefaultErrorResponse) {
+  constructor(httpError, resource, action, parseErrorResponse = parseDefaultErrorResponse) {
     if (!(httpError instanceof HTTPError)) {
       throw httpError
     }
 
-    if (!resource || !method) {
-      throw new TypeError('The resource and method parameters are required')
+    if (!resource || !action) {
+      throw new TypeError('The resource and action parameters are required')
     }
 
-    super(`${resource}.${method} error: ${httpError.message}`)
-
+    super(`${resource}.${action} error: ${httpError.message}`)
     Error.captureStackTrace(this, this.constructor)
+    this.name = 'MWSError'
 
-    this.name = this.constructor.name
-    this.response = httpError.response
+    Object.defineProperty(this, 'response', {
+      value: httpError.response
+    })
 
-    if (this.response.body) {
-      this.body = parseErrorResponse(
+    Object.defineProperty(this, 'resource', {
+      enumerable: true,
+      value: resource
+    })
+
+    Object.defineProperty(this, 'action', {
+      enumerable: true,
+      value: action
+    })
+
+    if (httpError.response.body) {
+      const body = parseErrorResponse(
         '/*[local-name() = \'ErrorResponse\']',
         parseXml(httpError.response.body)
       )
+
+      Object.defineProperty(this, 'body', {
+        enumerable: true,
+        value: body
+      })
     }
   }
 }

--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -91,24 +91,40 @@ class MWSClient {
     return {pathname, data}
   }
 
-  get(resource, version, query, options) {
+  async get(resource, version, query, options) {
     const {mwsDomain} = this.settings
     const {pathname, data} = this.signData('GET', resource, version, query)
 
-    return apiClient.get(`https://${mwsDomain}${pathname}`, {
-      ...options,
-      searchParams: data
-    })
+    try {
+      return await apiClient.get(`https://${mwsDomain}${pathname}`, {
+        ...options,
+        searchParams: data
+      })
+    } catch (error) {
+      if (error instanceof got.HTTPError) {
+        throw new MWSError(error, resource, query.Action)
+      }
+
+      throw error
+    }
   }
 
-  post(resource, version, body, options) {
+  async post(resource, version, body, options) {
     const {mwsDomain} = this.settings
     const {pathname, data} = this.signData('POST', resource, version, body)
 
-    return apiClient.post(`https://${mwsDomain}${pathname}`, {
-      ...options,
-      form: data
-    })
+    try {
+      return await apiClient.post(`https://${mwsDomain}${pathname}`, {
+        ...options,
+        form: data
+      })
+    } catch (error) {
+      if (error instanceof got.HTTPError) {
+        throw new MWSError(error, resource, body.Action)
+      }
+
+      throw error
+    }
   }
 }
 

--- a/lib/client/models/products.js
+++ b/lib/client/models/products.js
@@ -167,32 +167,37 @@ class Products {
     asin,
     itemCondition
   }) {
-    try {
-      const {body} = await this.client.post(RESOURCE, VERSION, {
-        Action: 'GetLowestPricedOffersForASIN',
-        MarketplaceId: marketplaceId,
-        ASIN: asin,
-        ItemCondition: itemCondition
-      }, {
-        retry: {
-          retries: 20
-        }
-      })
+    const {body} = await this.client.post(RESOURCE, VERSION, {
+      Action: 'GetLowestPricedOffersForASIN',
+      MarketplaceId: marketplaceId,
+      ASIN: asin,
+      ItemCondition: itemCondition
+    }, {
+      retry: {
+        retries: 20
+      },
+      hooks: {
+        beforeError: [error => {
+          if (error.response && error.response.statusCode === 400) {
+            return new MWSError(
+              error,
+              RESOURCE,
+              'GetLowestPricedOffersForASIN',
+              parseGetLowestPricedOffersForAsinErrorResponse
+            )
+          }
 
-      const {getLowestPricedOffersForAsinResult} = parseGetLowestPricedOffersForAsinResponse(
-        '/products:GetLowestPricedOffersForASINResponse',
-        parseXml(body)
-      )
+          return error
+        }]
+      }
+    })
 
-      return getLowestPricedOffersForAsinResult
-    } catch (error) {
-      throw new MWSError(
-        error,
-        RESOURCE,
-        'GetLowestPricedOffersForASIN',
-        parseGetLowestPricedOffersForAsinErrorResponse
-      )
-    }
+    const {getLowestPricedOffersForAsinResult} = parseGetLowestPricedOffersForAsinResponse(
+      '/products:GetLowestPricedOffersForASINResponse',
+      parseXml(body)
+    )
+
+    return getLowestPricedOffersForAsinResult
   }
 
   async [_getLowestPricedOffersForSku]({
@@ -200,32 +205,37 @@ class Products {
     sellerSku,
     itemCondition
   }) {
-    try {
-      const {body} = await this.client.post(RESOURCE, VERSION, {
-        Action: 'GetLowestPricedOffersForSKU',
-        MarketplaceId: marketplaceId,
-        SellerSKU: sellerSku,
-        ItemCondition: itemCondition
-      }, {
-        retry: {
-          retries: 20
-        }
-      })
+    const {body} = await this.client.post(RESOURCE, VERSION, {
+      Action: 'GetLowestPricedOffersForSKU',
+      MarketplaceId: marketplaceId,
+      SellerSKU: sellerSku,
+      ItemCondition: itemCondition
+    }, {
+      retry: {
+        retries: 20
+      },
+      hooks: {
+        beforeError: [error => {
+          if (error.response && error.response.statusCode === 400) {
+            return new MWSError(
+              error,
+              RESOURCE,
+              'GetLowestPricedOffersForSKU',
+              parseGetLowestPricedOffersForSkuErrorResponse
+            )
+          }
 
-      const {getLowestPricedOffersForSkuResult} = parseGetLowestPricedOffersForSkuResponse(
-        '/products:GetLowestPricedOffersForSKUResponse',
-        parseXml(body)
-      )
+          return error
+        }]
+      }
+    })
 
-      return getLowestPricedOffersForSkuResult
-    } catch (error) {
-      throw new MWSError(
-        error,
-        RESOURCE,
-        'GetLowestPricedOffersForSKU',
-        parseGetLowestPricedOffersForSkuErrorResponse
-      )
-    }
+    const {getLowestPricedOffersForSkuResult} = parseGetLowestPricedOffersForSkuResponse(
+      '/products:GetLowestPricedOffersForSKUResponse',
+      parseXml(body)
+    )
+
+    return getLowestPricedOffersForSkuResult
   }
 
   async [_getServiceStatus]() {


### PR DESCRIPTION
Transform all `got.HTTPError`s into `MWSError`s, and parse `error.reponse.body` XML doc to `error.body`.

Use got error hooks to define custom error handler on custom API calls.