### PR TITLE
Fix invalid spaces encoding

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -4,7 +4,7 @@ const pkg = require('../../package.json')
 
 const MWSError = require('./error')
 const sign = require('./sign')
-const {cleanData} = require('./utils')
+const {cleanData, normalizeSearchParams} = require('./utils')
 const {getMarketplaces, getMarketplacesFromRegion} = require('./marketplaces')
 
 const Finances = require('./models/finances')
@@ -95,11 +95,10 @@ class MWSClient {
     const {mwsDomain} = this.settings
     const {pathname, data} = this.signData('GET', resource, version, query)
 
+    const searchParams = normalizeSearchParams(data)
+
     try {
-      return await apiClient.get(`https://${mwsDomain}${pathname}`, {
-        ...options,
-        searchParams: data
-      })
+      return await apiClient.get(`https://${mwsDomain}${pathname}?${searchParams}`, options)
     } catch (error) {
       if (error instanceof got.HTTPError) {
         throw new MWSError(error, resource, query.Action)
@@ -113,10 +112,15 @@ class MWSClient {
     const {mwsDomain} = this.settings
     const {pathname, data} = this.signData('POST', resource, version, body)
 
+    const searchParams = normalizeSearchParams(data)
+
     try {
       return await apiClient.post(`https://${mwsDomain}${pathname}`, {
         ...options,
-        form: data
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded; charset=utf-8'
+        },
+        body: searchParams
       })
     } catch (error) {
       if (error instanceof got.HTTPError) {

--- a/lib/client/sign.js
+++ b/lib/client/sign.js
@@ -1,17 +1,13 @@
 const crypto = require('crypto')
 
+const {normalizeSearchParams} = require('./utils')
+
 function sign(secretKey, {method, domain, path, data}) {
   const hmac = crypto.createHmac('sha256', secretKey)
+  const searchParams = normalizeSearchParams(data)
 
   hmac.update(`${method}\n${domain}\n${path}\n`)
-  const sp = new URLSearchParams(data)
-  sp.sort()
-
-  hmac.update(
-    sp
-      .toString()
-      .replace(/\+/g, '%20')
-  )
+  hmac.update(searchParams)
 
   return hmac.digest('base64')
 }

--- a/lib/client/utils.js
+++ b/lib/client/utils.js
@@ -19,4 +19,14 @@ function arrayToObject(key, data) {
   }, {})
 }
 
-module.exports = {cleanData, arrayToObject}
+function normalizeSearchParams(data) {
+  const sp = new URLSearchParams(data)
+  sp.sort()
+  return sp.toString().replace(/\+/g, '%20')
+}
+
+module.exports = {
+  cleanData,
+  arrayToObject,
+  normalizeSearchParams
+}


### PR DESCRIPTION
MWS doesn’t support `+` spaces in either query string or POST body, but only `%20`.

Related: https://github.com/sindresorhus/got/issues/1113