### PR TITLE
Remove chardet and use response charset

### DIFF
--- a/__tests__/lib/client/models/reports.js
+++ b/__tests__/lib/client/models/reports.js
@@ -41,6 +41,44 @@ describe('lib.client.models.reports', () => {
     expect(result).toEqual('Hello world!')
   })
 
+  it('should call GetReport and transform the encoding from ISO-8859-1 to UTF-8', async () => {
+    const {pathname, data} = client.signData('POST', 'Reports', '2009-01-01', {
+      Action: 'GetReport',
+      ReportId: 'REPORT-1'
+    })
+
+    nock(apiUrl)
+      .post(pathname, data)
+      .reply(200, Buffer.from('6eAg52EgdmEgPw==', 'base64'))
+
+    const result = await client.reports.getReport({
+      reportId: 'REPORT-1',
+      format: 'raw'
+    })
+
+    expect(result).toEqual('éà ça va ?')
+  })
+
+  it('should call GetReport and transform the encoding the specified encoding to UTF-8', async () => {
+    const {pathname, data} = client.signData('POST', 'Reports', '2009-01-01', {
+      Action: 'GetReport',
+      ReportId: 'REPORT-1'
+    })
+
+    nock(apiUrl)
+      .post(pathname, data)
+      .reply(200, Buffer.from('6eAg52EgdmEgPw==', 'base64'), {
+        'content-type': 'text/plain; charset=iso-8859-3'
+      })
+
+    const result = await client.reports.getReport({
+      reportId: 'REPORT-1',
+      format: 'raw'
+    })
+
+    expect(result).toEqual('éà ça va ?')
+  })
+
   it('should call GetReport and return a base64 string', async () => {
     const {pathname, data} = client.signData('POST', 'Reports', '2009-01-01', {
       Action: 'GetReport',

--- a/lib/client/charset.js
+++ b/lib/client/charset.js
@@ -1,5 +1,4 @@
 const contentType = require('content-type')
-const chardet = require('jschardet')
 
 function getCharset(res) {
   try {
@@ -11,10 +10,8 @@ function getCharset(res) {
     // Go on.
   }
 
-  const det = chardet.detect(res.body)
-  if (det.confidence >= 0.8) {
-    return det.encoding
-  }
+  // The MWS doc specifies this as the default charset.
+  return 'iso-8859-1'
 }
 
 module.exports = getCharset

--- a/lib/client/models/reports.js
+++ b/lib/client/models/reports.js
@@ -172,7 +172,7 @@ class Reports {
       }
     })
 
-    const charset = getCharset(res) || 'iso-8859-1'
+    const charset = getCharset(res)
 
     const raw = iconv.decode(
       res.body,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "date-fns": "^2.11.1",
     "got": "^10.7.0",
     "iconv-lite": "^0.5.1",
-    "jschardet": "^2.1.1",
     "libxmljs": "^0.19.7",
     "lodash": "^4.17.15"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4217,11 +4217,6 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-jschardet@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-2.1.1.tgz#af6f8fd0b3b0f5d46a8fd9614a4fce490575c184"
-  integrity sha512-pA5qG9Zwm8CBpGlK/lo2GE9jPxwqRgMV7Lzc/1iaPccw6v4Rhj8Zg2BTyrdmHmxlJojnbLupLeRnaPLsq03x6Q==
-
 jsdom@^15.2.1:
   version "15.2.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"


### PR DESCRIPTION
MWS doc specifies that the default charset used is ISO-8859-1.

Source: https://github.com/bizon/mws-api-doc/blob/master/doc/en_FR/dev_guide/DG_ISO8859.md
