### PR TITLE
Rename reports.requestReport’s marketplaces to marketplaceIdList

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ try {
   reportType | `String` |
   startDate | `Date` |
   endDate | `Date` |
-  marketplaces | `Array<String>` |
+  marketplaceIdList | `Array<String>` |
   reportOptions | `String` |
 </details>
 

--- a/__tests__/lib/client/models/__snapshots__/reports.js.snap
+++ b/__tests__/lib/client/models/__snapshots__/reports.js.snap
@@ -13,3 +13,18 @@ Array [
   ],
 ]
 `;
+
+exports[`lib.client.models.reports should call RequestReport 1`] = `
+Object {
+  "completedDate": null,
+  "endDate": 2009-02-13T02:10:39.000Z,
+  "generatedReportId": null,
+  "reportProcessingStatus": "_SUBMITTED_",
+  "reportRequestId": "2291326454",
+  "reportType": "_GET_MERCHANT_LISTINGS_DATA_",
+  "scheduled": false,
+  "startDate": 2009-01-21T02:10:39.000Z,
+  "startedProcessingDate": null,
+  "submittedDate": 2009-02-20T02:10:39.000Z,
+}
+`;

--- a/__tests__/lib/client/models/reports.js
+++ b/__tests__/lib/client/models/reports.js
@@ -23,6 +23,50 @@ describe('lib.client.models.reports', () => {
     client.reports.clearRestores()
   })
 
+  it('should call RequestReport', async () => {
+    const {pathname, data} = client.signData('POST', 'Reports', '2009-01-01', {
+      Action: 'RequestReport',
+      ReportType: '_GET_MERCHANT_LISTINGS_DATA_',
+      StartDate: '2009-01-03T18:12:21.000Z',
+      EndDate: '2008-06-26T18:12:21.000Z',
+      'MarketplaceIdList.Id.1': 'ATVPDKIKX0DER'
+    })
+
+    nock(apiUrl)
+      .post(pathname, data)
+      .reply(
+        200,
+        `<?xml version="1.0"?>
+        <RequestReportResponse xmlns="http://mws.amazonaws.com/doc/2009-01-01/">
+          <RequestReportResult>
+            <ReportRequestInfo>
+              <ReportRequestId>2291326454</ReportRequestId>
+              <ReportType>_GET_MERCHANT_LISTINGS_DATA_</ReportType>
+              <StartDate>2009-01-21T02:10:39+00:00</StartDate>
+              <EndDate>2009-02-13T02:10:39+00:00</EndDate>
+              <Scheduled>false</Scheduled>
+              <SubmittedDate>2009-02-20T02:10:39+00:00</SubmittedDate>
+              <ReportProcessingStatus>_SUBMITTED_</ReportProcessingStatus>
+            </ReportRequestInfo>
+          </RequestReportResult>
+          <ResponseMetadata>
+            <RequestId>88faca76-b600-46d2-b53c-0c8c4533e43a</RequestId>
+          </ResponseMetadata>
+        </RequestReportResponse>`
+      )
+
+    const result = await client.reports.requestReport({
+      reportType: '_GET_MERCHANT_LISTINGS_DATA_',
+      startDate: '2009-01-03T18:12:21',
+      endDate: '2008-06-26T18:12:21',
+      marketplaceIdList: [
+        'ATVPDKIKX0DER'
+      ]
+    })
+
+    expect(result).toMatchSnapshot()
+  })
+
   it('should call GetReport and return a raw string', async () => {
     const {pathname, data} = client.signData('POST', 'Reports', '2009-01-01', {
       Action: 'GetReport',

--- a/lib/client/models/reports.js
+++ b/lib/client/models/reports.js
@@ -47,11 +47,11 @@ class Reports {
     reportType,
     startDate,
     endDate,
-    marketplaces,
+    marketplaceIdList,
     reportOptions
   }) {
-    if (!marketplaces) {
-      marketplaces = this.client.settings.marketplaces.map(m => m.id)
+    if (!marketplaceIdList) {
+      marketplaceIdList = this.client.settings.marketplaces.map(m => m.id)
     }
 
     const {body} = await this.client.post(RESOURCE, VERSION, {
@@ -61,7 +61,7 @@ class Reports {
       EndDate: parseDate(endDate),
       ReportOptions: reportOptions,
 
-      ...arrayToObject('MarketplaceIdList.Id', marketplaces)
+      ...arrayToObject('MarketplaceIdList.Id', marketplaceIdList)
     }, {
       retry: {
         retries: 15


### PR DESCRIPTION
This was done in order to match with the MWS API.