### PR TITLE
Allow passing reportOptions as an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,12 +555,15 @@ try {
 
   ```js
   const result = await client.reports.requestReport({
-    reportType: '_GET_MERCHANT_LISTINGS_DATA_',
+    reportType: '_GET_FLAT_FILE_OPEN_LISTINGS_DATA_',
     startDate: '2009-01-03T18:12:21',
     endDate: '2008-06-26T18:12:21',
     marketplaceIdList: [
       'ATVPDKIKX0DER'
-    ]
+    ],
+    reportOptions: {
+      custom: true
+    }
   })
   ```
 
@@ -572,7 +575,11 @@ try {
   startDate | `Date` |
   endDate | `Date` |
   marketplaceIdList | `Array<String>` |
-  reportOptions | `String` |
+  reportOptions | `String` or `Object` |
+
+  **Caveats:**
+
+  When defining `reportOptions` as an object, keep in mind that the options’ casing must match the [MWS documentation](https://github.com/bizon/mws-api-doc/blob/master/doc/en_FR/reports/Reports_ReportType.md).
 </details>
 
 <details>

--- a/__tests__/lib/client/utils.js
+++ b/__tests__/lib/client/utils.js
@@ -1,4 +1,8 @@
-const {dateToISOString} = require('../../../lib/client/utils')
+const {
+  dateToISOString,
+  normalizeSearchParams,
+  reportOptionsToString
+} = require('../../../lib/client/utils')
 
 describe('lib.client.utils', () => {
   describe('dateToISOString', () => {
@@ -45,6 +49,58 @@ describe('lib.client.utils', () => {
 
       for (const test of tests) {
         expect(dateToISOString(test)).toBe('2019-01-01T00:00:00.000Z')
+      }
+    })
+  })
+
+  describe('reportOptionsToString', () => {
+    it('should serialize ReportOptions', () => {
+      const tests = [
+        [
+          null,
+          null
+        ],
+        [
+          'custom=true',
+          'custom=true'
+        ],
+        [
+          {custom: true},
+          'custom=true'
+        ],
+        [
+          {MarketplaceId: 'ATVPDKIKX0DER', BrowseNodeId: '15706661'},
+          'MarketplaceId=ATVPDKIKX0DER;BrowseNodeId=15706661'
+        ]
+      ]
+
+      for (const [test, expected] of tests) {
+        expect(reportOptionsToString(test)).toBe(expected)
+      }
+    })
+
+    it('should serialize ReportOptions search param', () => {
+      const tests = [
+        [
+          'custom=true',
+          'ReportOptions=custom%3Dtrue'
+        ],
+        [
+          {custom: true},
+          'ReportOptions=custom%3Dtrue'
+        ],
+        [
+          {MarketplaceId: 'ATVPDKIKX0DER', BrowseNodeId: '15706661'},
+          'ReportOptions=MarketplaceId%3DATVPDKIKX0DER%3BBrowseNodeId%3D15706661'
+        ]
+      ]
+
+      for (const [test, expected] of tests) {
+        expect(
+          normalizeSearchParams({
+            ReportOptions: reportOptionsToString(test)
+          })
+        ).toBe(expected)
       }
     })
   })

--- a/lib/client/models/reports.js
+++ b/lib/client/models/reports.js
@@ -2,8 +2,12 @@ const parseCsv = require('csv-parse')
 const iconv = require('iconv-lite')
 
 const throttle = require('../throttle')
-const {dateToISOString, arrayToObject} = require('../utils')
 const getCharset = require('../charset')
+const {
+  arrayToObject,
+  dateToISOString,
+  reportOptionsToString
+} = require('../utils')
 
 const parseXml = require('../parsers')
 const parseRequestReportResponse = require('../parsers/reports/request-report-response')
@@ -59,7 +63,7 @@ class Reports {
       ReportType: reportType,
       StartDate: dateToISOString(startDate),
       EndDate: dateToISOString(endDate),
-      ReportOptions: reportOptions,
+      ReportOptions: reportOptionsToString(reportOptions),
 
       ...arrayToObject('MarketplaceIdList.Id', marketplaceIdList)
     }, {

--- a/lib/client/utils.js
+++ b/lib/client/utils.js
@@ -47,9 +47,21 @@ function normalizeSearchParams(data) {
   return sp.toString().replace(/\+/g, '%20')
 }
 
+function reportOptionsToString(data) {
+  if (data && typeof data === 'object') {
+    return Object
+      .entries(data)
+      .map(([key, value]) => `${key}=${String(value)}`)
+      .join(';')
+  }
+
+  return data
+}
+
 module.exports = {
   cleanData,
   dateToISOString,
   arrayToObject,
-  normalizeSearchParams
+  normalizeSearchParams,
+  reportOptionsToString
 }


### PR DESCRIPTION
Example:

```js
const result = await seller.reports.requestReport({
  reportType: '_GET_XML_BROWSE_TREE_DATA_',
  reportOptions: {
    MarketplaceId: getMarketplaceByCode('de').id,
    BrowseNodeId: '2810150031'
  }
})
```