### PR TITLE
Support marketplace domains in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ in | mws.amazonservices.in | India
 jp | mws.amazonservices.jp | Japan
 au | mws.amazonservices.com.au | Australia
 
-This library also allows to specify a list of marketplaces (either 2 letter country codes or Marketplaces IDs) so you can restrict API calls to your marketplace participations:
+This library also allows to specify a list of marketplaces (either 2 letter country codes, marketplace IDs or domains) so you can restrict API calls to your marketplace participations:
 
 ```js
 const client = new MWSClient({
@@ -62,7 +62,8 @@ const client = new MWSClient({
   mwsToken: '',
   marketplaces: [
     'A1F83G8C2ARO7P', // UK
-    'fr'
+    'fr',
+    'Amazon.it'
   ]
 })
 ```

--- a/__tests__/lib/client/index.js
+++ b/__tests__/lib/client/index.js
@@ -60,8 +60,8 @@ describe('lib.client.index', () => {
   it('should fail when passing invalid marketplaces', () => {
     const tests = [
       [[], 'Specify one of mwsRegion or marketplaces'],
-      [['332'], '332 is not a valid marketplace code or ID'],
-      [['fr', 'unknown'], 'unknown is not a valid marketplace code or ID']
+      [['332'], '332 is not a valid marketplace code, ID or domain'],
+      [['fr', 'unknown'], 'unknown is not a valid marketplace code, ID or domain']
     ]
 
     for (const [marketplaces, error] of tests) {

--- a/__tests__/lib/client/marketplaces.js
+++ b/__tests__/lib/client/marketplaces.js
@@ -41,12 +41,13 @@ describe('lib.client.marketplaces', () => {
           'what',
           'A1PA6795UKMFR9'
         ])
-      ).toThrow('what is not a valid marketplace code or ID')
+      ).toThrow('what is not a valid marketplace code, ID or domain')
     })
 
     it('should deduplicate marketplaces', () => {
       expect(getMarketplaces([
         'fr',
+        'amazon.fr',
         'A13V1IB3VIYZZH' // France
       ])).toHaveLength(1)
     })

--- a/lib/client/marketplaces.js
+++ b/lib/client/marketplaces.js
@@ -1,5 +1,10 @@
-const {getMarketplaceByCode, getMarketplaceById, getMarketplacesByMwsDomain} = require('@bizon/amazon-ids')
 const _ = require('lodash')
+const {
+  getMarketplaceByCode,
+  getMarketplaceByDomain,
+  getMarketplaceById,
+  getMarketplacesByMwsDomain
+} = require('@bizon/amazon-ids')
 
 const mwsRegionDomains = {
   // Generic MWS regions:
@@ -29,10 +34,10 @@ function getMarketplacesFromRegion(region) {
 function getMarketplaces(source) {
   const marketplaces = _(source)
     .map(s => {
-      const marketplace = getMarketplaceById(s) || getMarketplaceByCode(s)
+      const marketplace = getMarketplaceById(s) || getMarketplaceByCode(s) || getMarketplaceByDomain(s)
 
       if (!marketplace) {
-        throw new TypeError(`${s} is not a valid marketplace code or ID`)
+        throw new TypeError(`${s} is not a valid marketplace code, ID or domain`)
       }
 
       return marketplace


### PR DESCRIPTION
This uses [`getMarketplaceByDomain`](https://github.com/bizon/amazon-ids#getmarketplacebydomaindomain) from `@bizon/amazon-ids` – which is case-insensitive.