### PR TITLE
Ignore unknown marketplaces instead of throwing

### DIFF
--- a/__tests__/lib/client/__snapshots__/marketplaces.js.snap
+++ b/__tests__/lib/client/__snapshots__/marketplaces.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib.client.marketplaces getMarketplaces should filter out unknown marketplaces 1`] = `
+Array [
+  Object {
+    "advertisingApiDomain": "advertising-api-eu.amazon.com",
+    "code": "fr",
+    "domain": "amazon.fr",
+    "id": "A13V1IB3VIYZZH",
+    "imagesDomain": "images-eu.ssl-images-amazon.com",
+    "mwsDomain": "mws-eu.amazonservices.com",
+    "name": "France",
+    "region": "eu",
+    "vendorId": "A1X6FK5RDHNB96",
+  },
+  Object {
+    "advertisingApiDomain": "advertising-api-eu.amazon.com",
+    "code": "de",
+    "domain": "amazon.de",
+    "id": "A1PA6795UKMFR9",
+    "imagesDomain": "images-eu.ssl-images-amazon.com",
+    "mwsDomain": "mws-eu.amazonservices.com",
+    "name": "Germany",
+    "region": "eu",
+    "vendorId": "A3JWKAKR8XB7XF",
+  },
+]
+`;
+
 exports[`lib.client.marketplaces getMarketplaces should ignore marketplaces without an API endpoint 1`] = `
 Array [
   Object {

--- a/__tests__/lib/client/index.js
+++ b/__tests__/lib/client/index.js
@@ -57,11 +57,10 @@ describe('lib.client.index', () => {
     ).toThrow('unknown is not a valid MWS region')
   })
 
-  it('should fail when passing invalid marketplaces', () => {
+  it('should fail when none of the specified marketplaces are valid', () => {
     const tests = [
       [[], 'Specify one of mwsRegion or marketplaces'],
-      [['332'], '332 is not a valid marketplace code, ID or domain'],
-      [['fr', 'unknown'], 'unknown is not a valid marketplace code, ID or domain']
+      [['332'], 'None of the specified marketplaces define a MWS domain']
     ]
 
     for (const [marketplaces, error] of tests) {

--- a/__tests__/lib/client/marketplaces.js
+++ b/__tests__/lib/client/marketplaces.js
@@ -23,14 +23,14 @@ describe('lib.client.marketplaces', () => {
   })
 
   describe('getMarketplaces', () => {
-    it('should throw if one of the requested marketplaces does not exist', () => {
-      expect(
-        () => getMarketplaces([
-          'fr',
-          'what',
-          'A1PA6795UKMFR9'
-        ])
-      ).toThrow('what is not a valid marketplace code, ID or domain')
+    it('should filter out unknown marketplaces', () => {
+      const marketplaces = getMarketplaces([
+        'fr',
+        'what',
+        'A1PA6795UKMFR9'
+      ])
+
+      expect(marketplaces).toMatchSnapshot()
     })
 
     it('should deduplicate marketplaces', () => {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,7 @@
 const nock = require('nock')
 
+process.env.DEBUG = 'bizon:mws-sdk:*'
+
 async function setup() {
   nock.disableNetConnect()
 }

--- a/lib/client/marketplaces.js
+++ b/lib/client/marketplaces.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const debug = require('debug')('bizon:mws-sdk:marketplaces')
 const {
   getMarketplaceByCode,
   getMarketplaceByDomain,
@@ -22,12 +23,12 @@ function getMarketplaces(source) {
       const marketplace = getMarketplaceById(s) || getMarketplaceByCode(s) || getMarketplaceByDomain(s)
 
       if (!marketplace) {
-        throw new TypeError(`${s} is not a valid marketplace code, ID or domain`)
+        debug(`'${s}' is not a valid marketplace code, ID or domain`)
       }
 
       return marketplace
     })
-    .filter(m => m.mwsDomain)
+    .filter(m => m && m.mwsDomain)
     .uniqBy(m => m.id)
     .value()
 
@@ -36,7 +37,11 @@ function getMarketplaces(source) {
     .uniq()
     .value()
 
-  if (mwsDomains.length !== 1) {
+  if (mwsDomains.length === 0) {
+    throw new TypeError('None of the specified marketplaces define a MWS domain')
+  }
+
+  if (mwsDomains.length > 1) {
     throw new TypeError(`The specified marketplaces should all be on the same MWS domain, found ${mwsDomains}`)
   }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "content-type": "^1.0.4",
     "csv-parse": "^4.12.0",
     "date-fns": "^2.15.0",
+    "debug": "^4.1.1",
     "got": "^11.5.2",
     "iconv-lite": "^0.6.2",
     "libxmljs": "^0.19.7",


### PR DESCRIPTION
Unknown marketplaces used to throw an error, we’re now filtering (and debugging) the unknown marketplaces.

Throw a different error when there are no valid marketplaces specified.